### PR TITLE
Add -hostname CLI flag

### DIFF
--- a/chasquid.go
+++ b/chasquid.go
@@ -35,7 +35,7 @@ import (
 
 // Command-line flags.
 var (
-        hostname = flag.String("hostname", "", "overrides config's hostname if specified")
+	hostname  = flag.String("hostname", "", "overrides config's hostname if specified")
 	configDir = flag.String("config_dir", "/etc/chasquid",
 		"configuration directory")
 	showVer = flag.Bool("version", false, "show version and exit")
@@ -75,9 +75,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error reading config: %v", err)
 	}
-        if *hostname != "" {
-            conf.Hostname = *hostname
-        }
+	if *hostname != "" {
+		conf.Hostname = *hostname
+	}
 	config.LogConfig(conf)
 
 	// Change to the config dir.

--- a/chasquid.go
+++ b/chasquid.go
@@ -35,6 +35,7 @@ import (
 
 // Command-line flags.
 var (
+        hostname = flag.String("hostname", "", "overrides config's hostname if specified")
 	configDir = flag.String("config_dir", "/etc/chasquid",
 		"configuration directory")
 	showVer = flag.Bool("version", false, "show version and exit")
@@ -74,6 +75,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error reading config: %v", err)
 	}
+        if *hostname != "" {
+            conf.Hostname = *hostname
+        }
 	config.LogConfig(conf)
 
 	// Change to the config dir.


### PR DESCRIPTION
Allows overriding the configured hostname.

I'm using this in a docker container to have `-hostname $HOSTNAME` in the startup script, to be able to configure the hostname at runtime.
This can also help to use the output of `hostname --fqdn` as the hostname as requested [here](https://groups.google.com/forum/#!topic/chasquid/homF_3SnBp8).

PS: Once my container is all done, I'll send a message on the mailing list with a link and explanation for how it differs from the one in the repo :)