### PR TITLE
Use configured hostname for outgoing mail SMTP banner

### DIFF
--- a/chasquid.go
+++ b/chasquid.go
@@ -160,7 +160,7 @@ func main() {
 		Args:    conf.MailDeliveryAgentArgs,
 		Timeout: 30 * time.Second,
 	}
-	remoteC := &courier.SMTP{Dinfo: dinfo, STSCache: stsCache}
+	remoteC := &courier.SMTP{Hostname: conf.Hostname, Dinfo: dinfo, STSCache: stsCache}
 	s.InitQueue(conf.DataDir+"/queue", localC, remoteC)
 
 	// Load the addresses and listeners.


### PR DESCRIPTION
Chasquid was using the email's domain which isn't always correct, so we might as well use the config's hostname :)