### PR TITLE
Log rotating support

### DIFF
--- a/chasquid.go
+++ b/chasquid.go
@@ -14,8 +14,10 @@ import (
 	"math/rand"
 	"net"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
+	"syscall"
 	"time"
 
 	"blitiri.com.ar/go/chasquid/internal/config"
@@ -89,6 +91,8 @@ func main() {
 	}
 
 	initMailLog(conf.MailLogPath)
+
+	go signalHandler()
 
 	if conf.MonitoringAddress != "" {
 		launchMonitoringServer(conf.MonitoringAddress)
@@ -221,6 +225,29 @@ func initMailLog(path string) {
 
 	if err != nil {
 		log.Fatalf("Error opening mail log: %v", err)
+	}
+}
+
+// goroutine that reopens logs on SIGHUP
+func signalHandler() {
+	var err error
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGHUP)
+
+	for {
+		switch sig := <- signals; sig {
+		case syscall.SIGHUP:
+			err = log.Default.Reopen()
+			if err != nil {
+				log.Fatalf("Could not reopened log: %v", err)
+			}
+
+			err = maillog.Default.Reopen()
+			if err != nil {
+				log.Fatalf("Could not reopened mail log: %v", err)
+			}
+		}
 	}
 }
 

--- a/chasquid.go
+++ b/chasquid.go
@@ -216,9 +216,7 @@ func initMailLog(path string) {
 		maillog.Default, err = maillog.NewSyslog()
 	} else {
 		_ = os.MkdirAll(filepath.Dir(path), 0775)
-		var f *os.File
-		f, err = os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0664)
-		maillog.Default = maillog.New(f)
+		maillog.Default, err = maillog.NewFile(path)
 	}
 
 	if err != nil {

--- a/internal/maillog/maillog.go
+++ b/internal/maillog/maillog.go
@@ -60,6 +60,11 @@ func (l *Logger) printf(format string, args ...interface{}) {
 	}
 }
 
+// Reopen the underlying logger.
+func (l *Logger) Reopen() error {
+	return l.inner.Reopen()
+}
+
 // Listening logs that the daemon is listening on the given address.
 func (l *Logger) Listening(a string) {
 	l.printf("daemon listening on %s\n", a)


### PR DESCRIPTION
I would like to be able to use logrotate to manage chasquids logs, but there was no way to tell chasquid to flush and reopen its log file.
I saw that your log package has a [Reopen](https://pkg.go.dev/blitiri.com.ar/go/log?tab=doc#Logger.Reopen) function but is marked as experimental. I went ahead and used it to implement log reopening here.

I ported maillog to use your log package to be able to reopen it. To do so I had to modify log to add output format configuration, see https://github.com/albertito/log/pull/2.