### PR TITLE
Log to Stdout

### DIFF
--- a/chasquid.go
+++ b/chasquid.go
@@ -217,7 +217,11 @@ func initMailLog(path string) {
 	} else {
 		_ = os.MkdirAll(filepath.Dir(path), 0775)
 		var f *os.File
-		f, err = os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0664)
+		if path == "<stdout>" {
+			f = os.Stdout
+		} else {
+			f, err = os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0664)
+		}
 		maillog.Default = maillog.New(f)
 	}
 


### PR DESCRIPTION
Currently it is not possible to use `/dev/stdout` if chasquid is running as an unprivileged user since it will try to set a bad file mode on the special file (0664).  
  
This PR adds the `<stdout>` syntaxt to the config file to log to stdout