### PR TITLE
Add @domain to chasquid-util --help where appropriate

### DIFF
--- a/cmd/chasquid-util/chasquid-util.go
+++ b/cmd/chasquid-util/chasquid-util.go
@@ -29,9 +29,9 @@ import (
 // Usage, which doubles as parameter definitions thanks to docopt.
 const usage = `
 Usage:
-  chasquid-util [options] user-add <username> [--password=<password>]
-  chasquid-util [options] user-remove <username>
-  chasquid-util [options] authenticate <username> [--password=<password>]
+  chasquid-util [options] user-add <username@domain> [--password=<password>]
+  chasquid-util [options] user-remove <username@domain>
+  chasquid-util [options] authenticate <username@domain> [--password=<password>]
   chasquid-util [options] check-userdb <domain>
   chasquid-util [options] aliases-resolve <address>
   chasquid-util [options] domaininfo-remove <domain>

--- a/cmd/chasquid-util/chasquid-util.go
+++ b/cmd/chasquid-util/chasquid-util.go
@@ -29,9 +29,9 @@ import (
 // Usage, which doubles as parameter definitions thanks to docopt.
 const usage = `
 Usage:
-  chasquid-util [options] user-add <username@domain> [--password=<password>]
-  chasquid-util [options] user-remove <username@domain>
-  chasquid-util [options] authenticate <username@domain> [--password=<password>]
+  chasquid-util [options] user-add <user@domain> [--password=<password>]
+  chasquid-util [options] user-remove <user@domain>
+  chasquid-util [options] authenticate <user@domain> [--password=<password>]
   chasquid-util [options] check-userdb <domain>
   chasquid-util [options] aliases-resolve <address>
   chasquid-util [options] domaininfo-remove <domain>


### PR DESCRIPTION
This makes it more clear how to specify which domain the user being operated on is the sub-command targeting when using `--help`. It also uses `user@domain` to be consistent with the man page.