### PR TITLE
Use dkimpy for generating DKIM signatures

### DIFF
--- a/docs/dkim.md
+++ b/docs/dkim.md
@@ -8,7 +8,7 @@ mechanism.
 ## Signing
 
 The example hook in this repository contains an example of integration with
-[driusan/dkim](https://github.com/driusan/dkim) tools, and assumes the
+[dkimpy](https://launchpad.net/dkimpy/) tools, and assumes the
 following:
 
 - The [selector](https://tools.ietf.org/html/rfc6376#section-3.1) for a domain
@@ -18,6 +18,23 @@ following:
 
 Only authenticated email will be signed.
 
+```
+# for Ubuntu 20.04
+apt install dkimpy-milter opendkim-tools
+cd $(mktemp -d)
+DKIM_DOMAINS='example.com example.org'
+DKIM_SELECTOR="$(date +%y%b%d)"
+for i in ${DKIM_DOMAINS}; do
+	mkdir $i /etc/chasquid/certs/$i /etc/chasquid/domains/$i
+	opendkim-genkey -rSd $i -s $DKIM_SELECTOR -d $i
+	mv $i/${DKIM_SELECTOR}.private /etc/chasquid/certs/$i/dkim_privkey.pem
+	setfacl -m u:chasquid:r /etc/chasquid/certs/$i/dkim_privkey.pem
+	mv $i/${DKIM_SELECTOR}.txt /etc/chasquid/domains/$i/dkim_dns_record
+	echo ${DKIM_SELECTOR} > /etc/chasquid/domains/$i/dkim_selector
+done
+# add DKIM record to DNS
+cat /etc/chasquid/domains/*/dkim_dns_record
+```
 
 ## Verification
 

--- a/etc/chasquid/hooks/post-data
+++ b/etc/chasquid/hooks/post-data
@@ -7,7 +7,7 @@
 #  - spamc (from Spamassassin) to filter spam.
 #  - rspamc (from rspamd) to filter spam.
 #  - clamdscan (from ClamAV) to filter virus.
-#  - dkimsign (from driusan/dkim) to do DKIM signing.
+#  - dkimsign (from dkimpy) to do DKIM signing.
 #
 # If it exits with code 20, it will be considered a permanent error.
 # Otherwise, temporary.
@@ -73,7 +73,7 @@ if command -v clamdscan >/dev/null; then
         echo "X-Virus-Scanned: pass"
 fi
 
-# DKIM sign with https://github.com/driusan/dkim.
+# DKIM sign with https://launchpad.net/dkimpy/.
 #
 # Do it only if all the following are true:
 #  - User has authenticated.
@@ -86,10 +86,12 @@ if [ "$AUTH_AS" != "" ] && command -v dkimsign >/dev/null; then
 	DOMAIN=$( echo "$MAIL_FROM" | cut -d '@' -f 2 )
 	if [ -f "domains/$DOMAIN/dkim_selector" ] \
 			&& [ -f "certs/$DOMAIN/dkim_privkey.pem" ]; then
-		dkimsign -n -hd \
-			-key "certs/$DOMAIN/dkim_privkey.pem" \
-			-s "$(cat "domains/$DOMAIN/dkim_selector")" \
-			-d "$DOMAIN" \
-			< "$TF"
+		dkimsign \
+			"$(cat "domains/$DOMAIN/dkim_selector")" \
+			"$DOMAIN" \
+			"certs/$DOMAIN/dkim_privkey.pem" \
+			< "$TF" > "${TF}.signed"
+		echo "$( comm -13 "$TF" "${TF}.signed" )"
+		rm "${TF}.signed"
 	fi
 fi


### PR DESCRIPTION
Compared to  driusan/dkim, [dkimpy](https://launchpad.net/dkimpy/) is actively maintained and available on many distros (Ubuntu, Fedora, Debian, etc).

This PR would make enabling DKIM an easier procedure, without cloning driusan/dkim or compile & install.