### PR TITLE
introduce catch-all alias resolution

### DIFF
--- a/internal/aliases/aliases_test.go
+++ b/internal/aliases/aliases_test.go
@@ -315,3 +315,28 @@ func TestManyFiles(t *testing.T) {
 
 	check()
 }
+
+const noCatchAllFile = `
+	a: b@dom
+	b: c@dom
+	_: a
+`
+
+func TestHaveCatchAllNoAliasIsSet(t *testing.T) {
+	fname := mustWriteFile(t, noCatchAllFile)
+	defer os.Remove(fname)
+
+	resolver := NewResolver()
+	err := resolver.AddAliasesFile("dom", fname)
+	if err != nil {
+		t.Fatalf("failed to add file: %v", err)
+	}
+	rcpts, err := resolver.Resolve("e@dom")
+	if err != nil || len(rcpts) != 1 || rcpts[0].Addr != "e@dom" {
+		t.Fatalf("expected to have no error and same recipient returned, got %v, %v", rcpts, err)
+	}
+	expected := "a@dom"
+	if ca := resolver.CatchAllAddress("dom"); ca != expected {
+		t.Fatalf("expected %v, got %v catch-all address", expected, ca)
+	}
+}

--- a/internal/smtpsrv/conn.go
+++ b/internal/smtpsrv/conn.go
@@ -595,9 +595,15 @@ func (c *Conn) RCPT(params string) (code int, msg string) {
 			return 451, "4.4.3 Temporary error checking address"
 		}
 		if !ok {
-			maillog.Rejected(c.remoteAddr, c.mailFrom, []string{addr},
-				"local user does not exist")
-			return 550, "5.1.1 Destination address is unknown (user does not exist)"
+			domain := envelope.DomainOf(addr)
+			ca := c.aliasesR.CatchAllAddress(domain)
+			if ca != "" {
+				addr = ca
+			} else {
+				maillog.Rejected(c.remoteAddr, c.mailFrom, []string{addr},
+					"local user does not exist")
+				return 550, "5.1.1 Destination address is unknown (user does not exist)"
+			}
 		}
 	}
 


### PR DESCRIPTION
A "catch-all" alias is an optional, special form of an alias that
applies in a very last step of resolution (i.e. after running aliases
hooks), if no aliases could be found for the user name so far.

Addresses GitHub issue #23.