### PR TITLE
fix command -v dkimsign > /dev/null not work

### DIFF
--- a/etc/chasquid/hooks/post-data
+++ b/etc/chasquid/hooks/post-data
@@ -88,7 +88,7 @@ fi
 #  - certs/$DOMAIN/dkim_privkey.pem file exists.
 #
 # Note this has not been thoroughly tested, so might need further adjustments.
-if [ "$AUTH_AS" != "" ] && command -v dkimsign >/dev/null; then
+if [ "$AUTH_AS" != "" ] && [ -x "$(command -v dkimsign)" ]; then
 	DOMAIN=$( echo "$MAIL_FROM" | cut -d '@' -f 2 )
 
 	if [ -f "domains/$DOMAIN/dkim_selector" ] \


### PR DESCRIPTION
see the imgage ![](https://pub-b8db533c86124200a9d799bf3ba88099.r2.dev/2023/03/nLDPewH.webp) GNU bash, version 5.1.16(1)-release
command -v dkimsign > /dev/null not work