### PR TITLE
Fix using a domain directory path as a domain name.

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -62,7 +62,7 @@ for i in /etc/letsencrypt/live/*; do
 done
 
 # We need one domain to use as a default - pick the last one.
-ONE_DOMAIN=$i
+ONE_DOMAIN=$D
 
 # Check that there's at least once certificate at this point.
 if [ "$CERT_DOMAINS" == "" ]; then


### PR DESCRIPTION
This causes an invalid config in the generated /etc/dovecot/auto-ssl.conf, e.g.:

```
ssl_cert = </etc/letsencrypt/live//etc/letsencrypt/live/mail.example.com/fullchain.pem ssl_key = </etc/letsencrypt/live//etc/letsencrypt/live/mail.example.com/privkey.pem
```