### PR TITLE
`docker/add-user.sh`: Don't crash on updating when there is a single user

### DIFF
--- a/docker/add-user.sh
+++ b/docker/add-user.sh
@@ -7,16 +7,19 @@
 
 set -e
 
-read -r -p "Email (full user@domain format): " EMAIL
+if test -z "${EMAIL:-}"; then
+        read -r -p "Email (full user@domain format): " EMAIL
+fi
 
 if ! echo "${EMAIL}" | grep -q @; then
 	echo "Error: email should have '@'."
 	exit 1
 fi
 
-
-read -r -p "Password: " -s PASSWORD
-echo
+if test -z "${PASSWORD:-}"; then
+        read -r -p "Password: " -s PASSWORD
+        echo
+fi
 
 DOMAIN=$(echo echo "${EMAIL}" | cut -d '@' -f 2)
 

--- a/docker/add-user.sh
+++ b/docker/add-user.sh
@@ -34,11 +34,7 @@ ENCPASS=$(doveadm pw -u "${EMAIL}" -p "${PASSWORD}")
 # Edit dovecot users: remove user if it exits.
 mkdir -p /data/dovecot
 touch /data/dovecot/users
-if grep -q "^${EMAIL}:" /data/dovecot/users; then
-	cp /data/dovecot/users /data/dovecot/users.old
-	grep -v "^${EMAIL}:" /data/dovecot/users.old \
-		> /data/dovecot/users
-fi
+sed --in-place=.old "/^${EMAIL}:/d" /data/dovecot/users
 
 # Edit dovecot users: add user.
 echo "${EMAIL}:${ENCPASS}::::" >> /data/dovecot/users


### PR DESCRIPTION
When a single dovecot user exists and their password is updated,
the `grep -v` command intended to remove the user's old password
will not match any lines and fail, causing the entire script to fail.
