### PR TITLE
Support the LOGIN method to expand client compatibility

### DIFF
--- a/chasquid.go
+++ b/chasquid.go
@@ -109,6 +109,10 @@ func main() {
 		if err != nil {
 			log.Fatalf("Invalid name %+q: %v", info.Name(), err)
 		}
+		if info.Type().IsRegular() {
+			// Ignore regular files, we only care about directories.
+                        continue
+                }
 		dir := filepath.Join("domains", info.Name())
 		loadDomain(domain, dir, s)
 	}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get install -y -q \
 # built above.
 COPY --from=build /go/bin/chasquid /usr/bin/
 COPY --from=build /go/bin/chasquid-util /usr/bin/
+COPY --from=build /go/bin/dovecot-auth-cli /usr/bin/
 COPY --from=build /go/bin/smtp-check /usr/bin/
 COPY --from=build /go/bin/mda-lmtp /usr/bin/
 


### PR DESCRIPTION
Some clients do support TLS but use the LOGIN method, where the client
waits for a password prompt before sending the password, as opposed to the
currently-supported PLAIN method, where the client sends both username and
password as part of a single request. This minimal change attempts to support
the LOGIN method by parsing credentials, and then converting them into a
PLAIN-like auth string.
