### PR TITLE
make dkim-py example compatible with Alpine

### DIFF
--- a/etc/chasquid/hooks/post-data
+++ b/etc/chasquid/hooks/post-data
@@ -107,9 +107,7 @@ if [ "$AUTH_AS" != "" ] && command -v dkimsign >/dev/null; then
 			# dkimpy doesn't provide a way to just show the new
 			# headers, so we have to compute the difference.
 			# ALSOCHANGE(test/t-19-dkimpy/config/hooks/post-data)
-			diff --changed-group-format='%>' \
-				--unchanged-group-format='' \
-				"$TF" "$TF.dkimout" && exit 1
+			comm -3 "$TF.dkimout" "$TF"
 			rm "$TF.dkimout"
 		else
 			# driusan/dkim

--- a/test/t-19-dkimpy/config/hooks/post-data
+++ b/test/t-19-dkimpy/config/hooks/post-data
@@ -31,9 +31,7 @@ if [ "$AUTH_AS" != "" ]; then
 	# dkimpy doesn't provide a way to just show the new headers, so we
 	# have to compute the difference.
 	# ALSOCHANGE(etc/chasquid/hooks/post-data)
-	diff --changed-group-format='%>' \
-		--unchanged-group-format='' \
-		"$TF" "$TF.dkimout" && exit 1
+	comm -3 "$TF.dkimout" "$TF"
 	rm "$TF.dkimout"
 else
 	# NOTE: This is using driusan/dkim instead of dkimpy, because dkimpy can't be


### PR DESCRIPTION
Busybox's diff doesn't have the extended CLI flags, but it seems that `comm` works fine enough with dkim-py.

I originally tried the Go versions of the DKIM tools, but they consistently produced invalid signatures. For testing I am sending myself a local email via

```bash
echo -e "Subject: this is a test email\nTo: me@mydomain.com\n\n hello there username." | msmtp -v me@mydomain.com
```

When using dkim-go, the signature is only accepted by dkim-go, dkim-py rejects it with

> dkim.ValidationError: body hash mismatch (got b'nC3tBYkxSxy2Nw1wostkVwsDSyxn8WTIj5Uh9aI3U/c=', expected b'47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')

If I however use dkim-py, the signature is in turn only accepted by dkim-py. dkim-go rejects it likewise with

> <stdin>: Permanent failure: body hash does not match

Since mail-tester.com accepts dkim-py and rejects dkim-go, I for now went with the Python version and so needed Alpine compatibility :grin: 

(My test email might be broken; I don't know, but with the Python tooling things just work :shrug: )