### PR TITLE
chasquid-util: switch --configdir into --config_dir

### DIFF
--- a/cmd/chasquid-util/chasquid-util.go
+++ b/cmd/chasquid-util/chasquid-util.go
@@ -46,8 +46,8 @@ Usage:
     private key.
 
 Options:
-  -C=<path>, --configdir=<path>  Configuration directory
-  -v                             Verbose mode
+  -C=<path>, --config_dir=<path>  Configuration directory
+  -v                              Verbose mode
 `
 
 // Command-line arguments.
@@ -72,11 +72,15 @@ func main() {
 	}
 
 	// Load globals.
-	if d, ok := args["--configdir"]; ok {
+	if d, ok := args["--config_dir"]; ok {
 		configDir = d
 	}
 	if d, ok := args["-C"]; ok {
 		configDir = d
+	}
+	if d, ok := args["--configdir"]; ok {
+		configDir = d
+		Warnf("Option --configdir is deprecated, use --config_dir instead")
 	}
 
 	commands := map[string]func(){
@@ -110,6 +114,11 @@ func main() {
 func Fatalf(s string, arg ...interface{}) {
 	fmt.Fprintf(os.Stderr, s+"\n", arg...)
 	os.Exit(1)
+}
+
+// Warnf prints the given message to stderr, but does not exit the program.
+func Warnf(s string, arg ...interface{}) {
+	fmt.Fprintf(os.Stderr, s+"\n", arg...)
 }
 
 func userDBForDomain(domain string) string {

--- a/cmd/chasquid-util/test_bad_args.cmy
+++ b/cmd/chasquid-util/test_bad_args.cmy
@@ -1,21 +1,21 @@
 # Unknown argument.
-c = ./chasquid-util --configdir=.config blahrarghar
+c = ./chasquid-util --config_dir=.config blahrarghar
 c <- Unknown argument "blahrarghar"
 c wait 1
 
-c = ./chasquid-util --configdir=.nonono check-userdb
+c = ./chasquid-util --config_dir=.nonono check-userdb
 c <- Error: file ".nonono/domains//users" does not exist
 c wait 1
 
-c = ./chasquid-util --configdir=.nonono print-config
+c = ./chasquid-util --config_dir=.nonono print-config
 c <- Error loading config: failed to read config at ".nonono/chasquid.conf": open .nonono/chasquid.conf: no such file or directory
 c wait 1
 
-c = ./chasquid-util --configdir=.nonono aliases-resolve email@addr
+c = ./chasquid-util --config_dir=.nonono aliases-resolve email@addr
 c <- Error loading config: failed to read config at ".nonono/chasquid.conf": open .nonono/chasquid.conf: no such file or directory
 c wait 1
 
-c = ./chasquid-util --configdir=.nonono domaininfo-remove domain
+c = ./chasquid-util --config_dir=.nonono domaininfo-remove domain
 c <- Error loading config: failed to read config at ".nonono/chasquid.conf": open .nonono/chasquid.conf: no such file or directory
 c wait 1
 

--- a/cmd/chasquid-util/test_general.cmy
+++ b/cmd/chasquid-util/test_general.cmy
@@ -1,5 +1,5 @@
 # --help
-c = ./chasquid-util --configdir=.config --help
+c = ./chasquid-util --config_dir=.config --help
 c <-
 c <- Usage:
 c wait 0

--- a/docs/man/chasquid-util.1
+++ b/docs/man/chasquid-util.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "chasquid-util 1"
-.TH chasquid-util 1 "2023-12-03" "" ""
+.TH chasquid-util 1 "2025-03-21" "" ""
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -185,9 +185,12 @@ security level downgrade. Talks to the running chasquid instance.
 .IP "\fBprint-config\fR" 8
 .IX Item "print-config"
 Parse and print the configuration in a human-readable way.
-.IP "\fB\-C\fR or \fB\-\-configdir=<path\fR>" 8
-.IX Item "-C or --configdir=<path>"
+.IP "\fB\-C\fR or \fB\-\-config_dir=<path\fR>" 8
+.IX Item "-C or --config_dir=<path>"
 Configuration directory.
+.IP "\fB\-\-configdir=<path\fR>" 8
+.IX Item "--configdir=<path>"
+Deprecated alias for \fB\-\-config_dir=<path\fR>.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
 \&\fBchasquid\fR\|(1)

--- a/docs/man/chasquid-util.1.md
+++ b/docs/man/chasquid-util.1.md
@@ -56,9 +56,13 @@ chasquid-util is a command-line utility for [chasquid(1)](chasquid.1.md) operati
 
     Parse and print the configuration in a human-readable way.
 
-- **-C** or **--configdir=&lt;path**>
+- **-C** or **--config\_dir=&lt;path**>
 
     Configuration directory.
+
+- **--configdir=&lt;path**>
+
+    Deprecated alias for **--config\_dir=&lt;path**>.
 
 # SEE ALSO
 

--- a/docs/man/chasquid-util.1.pod
+++ b/docs/man/chasquid-util.1.pod
@@ -60,9 +60,13 @@ security level downgrade. Talks to the running chasquid instance.
 
 Parse and print the configuration in a human-readable way.
 
-=item B<-C> or B<--configdir=<path>>
+=item B<-C> or B<--config_dir=<path>>
 
 Configuration directory.
+
+=item B<--configdir=<path>>
+
+Deprecated alias for B<--config_dir=<path>>.
 
 =back
 


### PR DESCRIPTION
chasquid-util usage mentions  `--config_dir` but the option was ignored. This changes fixes that.