### PR TITLE
Replace ssl.wrap_socket with ssl.SSLContext().wrap_socket

### DIFF
--- a/test/util/chamuyero
+++ b/test/util/chamuyero
@@ -113,7 +113,7 @@ class TLSSock (Sock):
         host, port = addr.rsplit(":", 1)
         Sock.__init__(self, (host, int(port)))
         plain_sock = socket.create_connection(self.addr)
-        self.sock = ssl.wrap_socket(plain_sock)
+        self.sock = ssl.SSLContext().wrap_socket(plain_sock)
 
     def connect(self):
         self.connr = self.sock.makefile(mode="r", encoding="utf8")


### PR DESCRIPTION
ssl.wrap_socket is deprecated since Python 3.7 and has been removed since Python 3.11.