### PR TITLE
Force Unix line endings on docker image files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force Unix style line endings for files that will be copied into the Docker image
+docker/* text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Exceptions to the rules above: files we care about that would otherwise be
 # excluded.
 !.gitignore
+!.gitattributes
 !.clang-format
 !.github/
 


### PR DESCRIPTION
When using git on Windows, depending on the configuration git may try to "fix" line endings (convert them from Unix LF `\n` to Windows CRLF `\r\n`), and when building the Docker image on such machine, the files copied into the Docker image end up having incorrect line endings causing scripts (such as the entrypoint script) to fail to run. As such, it is best to use `.gitattributes` to force Unix LF line endings on such files.