### PR TITLE
Added instructions to cross-compile docker image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -26,6 +26,11 @@ If, instead, you want to build the image yourself, just run:
 $ docker build -t chasquid -f docker/Dockerfile .
 ```
 
+Or, if you are cross-compiling for a different architecture, e.g. `arm64`:
+
+```sh
+$ docker build --platform=linux/arm64 -t chasquid -f docker/Dockerfile .
+```
 
 ## Running
 


### PR DESCRIPTION
The target system platform may not be the same as the one where the Docker image is being built on, e.g. in my case I am building on an amd64 but deploying on arm.