### PR TITLE
Added --rm to the docker command for adding users

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -47,7 +47,7 @@ To add your first user to the image:
 ```
 $ docker run \
 	--mount source=chasquid-data,target=/data \
-	-it --entrypoint=/add-user.sh \
+	--rm -it --entrypoint=/add-user.sh \
 	registry.gitlab.com/albertito/chasquid:main
 Email (full user@domain format): pepe@example.com
 Password:


### PR DESCRIPTION
Without [--rm](https://docs.docker.com/reference/cli/docker/container/run/#rm) option, after the container exits the container remains created, so if we try to create a new container with the same name it will fail, and if we create it with a different name (default if name isn't specified) then we will have 2 containers created. Thus, when creating containers just to run a single command, for example to edit something in a volume, like we are doing here, we should include the `--rm` option so the container gets cleaned up after the user has been added.