### PR TITLE
Properly handle running daemons inside the Docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get install -y -q \
 	chasquid \
 	dovecot-lmtpd dovecot-imapd dovecot-pop3d \
 	dovecot-sieve dovecot-managesieved \
-	acl libcap2-bin sudo certbot
+	acl libcap2-bin gosu certbot
 
 # Copy the binaries. This overrides the debian packages with the ones we just
 # built above.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get install -y -q \
 	chasquid \
 	dovecot-lmtpd dovecot-imapd dovecot-pop3d \
 	dovecot-sieve dovecot-managesieved \
-	acl libcap2-bin gosu certbot
+	acl libcap2-bin certbot
 
 # Copy the binaries. This overrides the debian packages with the ones we just
 # built above.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -105,6 +105,4 @@ echo "hostname: '$ONE_DOMAIN'" >> /etc/chasquid/chasquid.conf
 # Start the services: dovecot in background, chasquid in foreground.
 start-stop-daemon --start --quiet --pidfile /run/dovecot.pid \
 	--exec /usr/sbin/dovecot -- -c /etc/dovecot/dovecot.conf
-
-# shellcheck disable=SC2086
-exec gosu chasquid:chasquid /usr/bin/chasquid $CHASQUID_FLAGS
+exec gosu chasquid:chasquid /usr/bin/chasquid "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -137,18 +137,40 @@ stop_daemons() {
 trap 'stop_daemons' SIGTERM SIGINT
 
 # Start the services: dovecot and chasquid.
-start-stop-daemon --start --quiet --background \
-	--chuid dovecot:dovecot --output /proc/self/fd/1 \
-	--pidfile /run/dovecot.pid --make-pidfile \
-	--exec /usr/sbin/dovecot -- -c /etc/dovecot/dovecot.conf
+start_dovecot() {
+	start-stop-daemon --start --quiet --background \
+		--chuid dovecot:dovecot --output /proc/self/fd/1 \
+		--pidfile /run/dovecot.pid --make-pidfile \
+		--exec /usr/sbin/dovecot -- -c /etc/dovecot/dovecot.conf
+}
+start_chasquid() {
+	# shellcheck disable=SC2086
+	start-stop-daemon --start --quiet --background \
+		--chuid chasquid:chasquid --output /proc/self/fd/1 \
+		--pidfile /run/chasquid.pid --make-pidfile \
+		--exec /usr/bin/chasquid "$@" $CHASQUID_FLAGS
+}
+start_dovecot; start_chasquid
 
-# shellcheck disable=SC2086
-start-stop-daemon --start --quiet --background \
-	--chuid chasquid:chasquid --output /proc/self/fd/1 \
-	--pidfile /run/chasquid.pid --make-pidfile \
-	--exec /usr/bin/chasquid "$@" $CHASQUID_FLAGS
+# Wait for the daemons to start.
+sleep 10
 
-# Keep waiting for the SIGTERM/SIGINT signal.
+# Keep waiting for the SIGTERM/SIGINT signal while monitoring for the daemon
+# statuses and restarting them if necessary.
 while true; do
-	tail -f /dev/null & wait ${!}
+	INTERVAL=60
+
+	if ! start-stop-daemon --status --quiet --pidfile /run/dovecot.pid; then
+		echo 1>&2 "Error: dovecot stopped unexpectedly ($?)"
+		start_dovecot
+		INTERVAL=10
+	fi
+
+	if ! start-stop-daemon --status --quiet --pidfile /run/chasquid.pid; then
+		echo 1>&2 "Error: chasquid stopped unexpectedly ($?)"
+		start_chasquid
+		INTERVAL=10
+	fi
+
+	sleep $INTERVAL
 done

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -108,7 +108,10 @@ if [ "$CHASQUID_FLAGS" != "" ]; then
 fi
 
 # Stop the sercives: dovecot and chasquid.
+STOP_INITIATED=0
 stop_daemons() {
+	STOP_INITIATED=1
+
 	echo "Stopping daemons..."
 	local exit_code=0
 	local result=0
@@ -170,16 +173,17 @@ half_sleep 10
 while true; do
 	INTERVAL=60
 
-	if ! start-stop-daemon --status --quiet --name dovecot; then
-		echo 1>&2 "Error: dovecot stopped unexpectedly ($?)"
-		start_dovecot
-		INTERVAL=10
-	fi
-
-	if ! start-stop-daemon --status --quiet --pidfile /run/chasquid.pid; then
-		echo 1>&2 "Error: chasquid stopped unexpectedly ($?)"
-		start_chasquid
-		INTERVAL=10
+	if [ $STOP_INITIATED -eq 0 ]; then
+		if ! start-stop-daemon --status --quiet --name dovecot; then
+			echo 1>&2 "Error: dovecot stopped unexpectedly ($?)"
+			start_dovecot
+			INTERVAL=10
+		fi
+		if ! start-stop-daemon --status --quiet --pidfile /run/chasquid.pid; then
+			echo 1>&2 "Error: chasquid stopped unexpectedly ($?)"
+			start_chasquid
+			INTERVAL=10
+		fi
 	fi
 
 	half_sleep $INTERVAL

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -89,8 +89,8 @@ ssl_key = </etc/letsencrypt/live/$ONE_DOMAIN/privkey.pem
 EOF
 for DOMAIN in $CERT_DOMAINS; do
 	echo "local_name $DOMAIN {"
-        echo "  ssl_cert = </etc/letsencrypt/live/$DOMAIN/fullchain.pem"
-        echo "  ssl_key = </etc/letsencrypt/live/$DOMAIN/privkey.pem"
+		echo "  ssl_cert = </etc/letsencrypt/live/$DOMAIN/fullchain.pem"
+		echo "  ssl_key = </etc/letsencrypt/live/$DOMAIN/privkey.pem"
 	echo "}"
 done >> /etc/dovecot/auto-ssl.conf
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -107,4 +107,4 @@ start-stop-daemon --start --quiet --pidfile /run/dovecot.pid \
 	--exec /usr/sbin/dovecot -- -c /etc/dovecot/dovecot.conf
 
 # shellcheck disable=SC2086
-exec sudo -u chasquid -g chasquid /usr/bin/chasquid $CHASQUID_FLAGS
+exec gosu chasquid:chasquid /usr/bin/chasquid $CHASQUID_FLAGS

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -107,4 +107,4 @@ start-stop-daemon --start --quiet --pidfile /run/dovecot.pid \
 	--exec /usr/sbin/dovecot -- -c /etc/dovecot/dovecot.conf
 
 # shellcheck disable=SC2086
-sudo -u chasquid -g chasquid  /usr/bin/chasquid  $CHASQUID_FLAGS
+exec sudo -u chasquid -g chasquid /usr/bin/chasquid $CHASQUID_FLAGS

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,8 +6,8 @@
 set -e
 
 if ! grep -q data /proc/mounts; then
-	echo "/data is not mounted."
-	echo "Check that the /data volume is set up correctly."
+	echo 1>&2 "/data is not mounted."
+	echo 1>&2 "Check that the /data volume is set up correctly."
 	exit 1
 fi
 
@@ -66,9 +66,9 @@ ONE_DOMAIN=$D
 
 # Check that there's at least once certificate at this point.
 if [ "$CERT_DOMAINS" == "" ]; then
-	echo "No certificates found."
-	echo
-	echo "Set AUTO_CERTS='example.com' to automatically get one."
+	echo 1>&2 "No certificates found."
+	echo 1>&2
+	echo 1>&2 "Set AUTO_CERTS='example.com' to automatically get one."
 	exit 1
 fi
 
@@ -104,7 +104,7 @@ echo "hostname: '$ONE_DOMAIN'" >> /etc/chasquid/chasquid.conf
 
 # Warn if the old variable CHASQUID_FLAGS is used for passing args
 if [ "$CHASQUID_FLAGS" != "" ]; then
-	echo 'CHASQUID_FLAGS environmental variable is deprecated. Use the command key instead: https://docs.docker.com/reference/compose-file/services/#command'
+	echo 1>&2 'CHASQUID_FLAGS environmental variable is deprecated. Use the command key instead: https://docs.docker.com/reference/compose-file/services/#command'
 fi
 
 # Start the services: dovecot in background, chasquid in foreground.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -114,7 +114,7 @@ stop_daemons() {
 	local result=0
 
 	# Send the SIGTERM signal to the services.
-	start-stop-daemon --stop --quiet --pidfile /run/dovecot.pid --signal TERM &
+	start-stop-daemon --stop --quiet --name dovecot --signal TERM &
 	dovecot_pid=$!
 	start-stop-daemon --stop --quiet --pidfile /run/chasquid.pid --signal TERM &
 	chasquid_pid=$!
@@ -138,9 +138,7 @@ trap 'stop_daemons' SIGTERM SIGINT
 
 # Start the services: dovecot and chasquid.
 start_dovecot() {
-	start-stop-daemon --start --quiet --background \
-		--chuid dovecot:dovecot --output /proc/self/fd/1 \
-		--pidfile /run/dovecot.pid --make-pidfile \
+	start-stop-daemon --start --quiet --name dovecot \
 		--exec /usr/sbin/dovecot -- -c /etc/dovecot/dovecot.conf
 }
 start_chasquid() {
@@ -160,7 +158,7 @@ sleep 10
 while true; do
 	INTERVAL=60
 
-	if ! start-stop-daemon --status --quiet --pidfile /run/dovecot.pid; then
+	if ! start-stop-daemon --status --quiet --name dovecot; then
 		echo 1>&2 "Error: dovecot stopped unexpectedly ($?)"
 		start_dovecot
 		INTERVAL=10

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -176,13 +176,13 @@ while true; do
 	if [ $STOP_INITIATED -eq 0 ]; then
 		if ! start-stop-daemon --status --quiet --name dovecot; then
 			echo 1>&2 "Error: dovecot stopped unexpectedly ($?)"
-			start_dovecot
-			INTERVAL=10
+			start-stop-daemon --stop --quiet --pidfile /run/chasquid.pid --signal TERM/10/KILL/10
+			exit 1
 		fi
 		if ! start-stop-daemon --status --quiet --pidfile /run/chasquid.pid; then
 			echo 1>&2 "Error: chasquid stopped unexpectedly ($?)"
-			start_chasquid
-			INTERVAL=10
+			start-stop-daemon --stop --quiet --name dovecot --signal TERM/10/KILL/10
+			exit 1
 		fi
 	fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -150,8 +150,20 @@ start_chasquid() {
 }
 start_dovecot; start_chasquid
 
+# Sleep for the total duration in small intervals to allow the response to signals.
+half_sleep() {
+	local total_sleep_time=$1
+	local sleep_interval=${2:-1}
+	local elapsed_time=0
+
+	while [[ $elapsed_time -lt $total_sleep_time ]]; do
+		sleep $sleep_interval
+		elapsed_time=$((elapsed_time + sleep_interval))
+	done
+}
+
 # Wait for the daemons to start.
-sleep 10
+half_sleep 10
 
 # Keep waiting for the SIGTERM/SIGINT signal while monitoring for the daemon
 # statuses and restarting them if necessary.
@@ -170,5 +182,5 @@ while true; do
 		INTERVAL=10
 	fi
 
-	sleep $INTERVAL
+	half_sleep $INTERVAL
 done

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -107,9 +107,48 @@ if [ "$CHASQUID_FLAGS" != "" ]; then
 	echo 1>&2 'CHASQUID_FLAGS environmental variable is deprecated. Use the command key instead: https://docs.docker.com/reference/compose-file/services/#command'
 fi
 
-# Start the services: dovecot in background, chasquid in foreground.
-start-stop-daemon --start --quiet --pidfile /run/dovecot.pid \
+# Stop the sercives: dovecot and chasquid.
+stop_daemons() {
+	echo "Stopping daemons..."
+	local exit_code=0
+	local result=0
+
+	# Send the SIGTERM signal to the services.
+	start-stop-daemon --stop --quiet --pidfile /run/dovecot.pid --signal TERM &
+	dovecot_pid=$!
+	start-stop-daemon --stop --quiet --pidfile /run/chasquid.pid --signal TERM &
+	chasquid_pid=$!
+
+	# Wait for the services to exit and check the exit codes.
+	wait "$dovecot_pid"; result=$?
+	if [ $result -ne 0 ]; then
+		echo 1>&2 "Error: dovecot exited with non-zero status ($result)."
+		exit_code=$result
+	fi
+	wait "$chasquid_pid"; result=$?
+	if [ $result -ne 0 ]; then
+		echo 1>&2 "Error: chasquid exited with non-zero status ($result)."
+		exit_code=$result
+	fi
+
+	echo "Daemons stopped."
+	exit $exit_code
+}
+trap 'stop_daemons' SIGTERM SIGINT
+
+# Start the services: dovecot and chasquid.
+start-stop-daemon --start --quiet --background \
+	--chuid dovecot:dovecot --output /proc/self/fd/1 \
+	--pidfile /run/dovecot.pid --make-pidfile \
 	--exec /usr/sbin/dovecot -- -c /etc/dovecot/dovecot.conf
 
 # shellcheck disable=SC2086
-exec gosu chasquid:chasquid /usr/bin/chasquid "$@" $CHASQUID_FLAGS
+start-stop-daemon --start --quiet --background \
+	--chuid chasquid:chasquid --output /proc/self/fd/1 \
+	--pidfile /run/chasquid.pid --make-pidfile \
+	--exec /usr/bin/chasquid "$@" $CHASQUID_FLAGS
+
+# Keep waiting for the SIGTERM/SIGINT signal.
+while true; do
+	tail -f /dev/null & wait ${!}
+done

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -102,7 +102,14 @@ done >> /etc/dovecot/auto-ssl.conf
 sed -i '/^hostname:/d' /etc/chasquid/chasquid.conf
 echo "hostname: '$ONE_DOMAIN'" >> /etc/chasquid/chasquid.conf
 
+# Warn if the old variable CHASQUID_FLAGS is used for passing args
+if [ "$CHASQUID_FLAGS" != "" ]; then
+	echo 'CHASQUID_FLAGS environmental variable is deprecated. Use the command key instead: https://docs.docker.com/reference/compose-file/services/#command'
+fi
+
 # Start the services: dovecot in background, chasquid in foreground.
 start-stop-daemon --start --quiet --pidfile /run/dovecot.pid \
 	--exec /usr/sbin/dovecot -- -c /etc/dovecot/dovecot.conf
-exec gosu chasquid:chasquid /usr/bin/chasquid "$@"
+
+# shellcheck disable=SC2086
+exec gosu chasquid:chasquid /usr/bin/chasquid "$@" $CHASQUID_FLAGS


### PR DESCRIPTION
In a Docker image the service should run as PID 1 to properly receive and handle SIGINT and such signals. Currently when stopping the container it takes >10 seconds, the maximum Docker will wait for a container to stop gracefully, after which Docker forcefully kills the proccess using SIGKILL, thus the container exits with code `137`.

I tried achieving this by using `exec` to have the chasquid process replace the entrypoint as PID 1, and used `gosu` instead of `sudo` which was specifically designed for the use in containers and such, however it still exits with code `1`. Since the container also runs dovecot, it might be more apropriate to use a small init system designed for docker containers, e.g. [tini](https://github.com/krallin/tini).

Also replaced `CHASQUID_FLAGS` with `$@`, arguments can be defined using the `command` key:

```yaml
services:
  chasquid:
    ...
    command:
      - arg1
      - arg2
    ...
```