### PR TITLE
Use bridge network instead of host network and improve the README

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,6 +55,9 @@ EXPOSE 993 995 4190
 # http for letsencrypt/certbot.
 EXPOSE 80 443
 
+# http for monitoring.
+EXPOSE 1099
+
 # Store emails and chasquid databases in an external volume, to be mounted at
 # /data, so they're independent from the image itself.
 VOLUME /data

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,9 +36,6 @@ RUN DEBIAN_FRONTEND=noninteractive \
 # built above.
 COPY --from=build /go/bin/chasquid /go/bin/chasquid-util /go/bin/smtp-check /go/bin/mda-lmtp /usr/bin/
 
-# Let chasquid bind privileged ports, so we can run it as its own user.
-RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/chasquid
-
 # Copy docker-specific configurations.
 COPY docker/dovecot.conf /etc/dovecot/dovecot.conf
 COPY docker/chasquid.conf /etc/chasquid/chasquid.conf
@@ -46,11 +43,11 @@ COPY docker/chasquid.conf /etc/chasquid/chasquid.conf
 # Copy utility scripts.
 COPY docker/add-user.sh docker/entrypoint.sh /
 
-# chasquid: SMTP, submission, submission+tls.
-EXPOSE 25 465 587
+# chasquid: SMTP (25), submission (465), submission+tls (587).
+EXPOSE 1025 1465 1587
 
-# dovecot: POP3s, IMAPs, managesieve.
-EXPOSE 993 995 4190
+# dovecot: POP3s (993), IMAPs (995), managesieve (4190).
+EXPOSE 1993 1995 4190
 
 # http for letsencrypt/certbot.
 EXPOSE 80 443

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,6 +80,9 @@ RUN rmdir /etc/chasquid/domains/ && \
 # critical notifications.
 ENV AUTO_CERTS=""
 
+# Enable monitoring HTTP server.
+ENV ENABLE_MONITORING=""
+
 # Custom entry point that does some configuration checks and ensures
 # letsencrypt is properly set up.
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -71,7 +71,7 @@ and not proxying.
 Finally, start the container:
 
 ```sh
-$ docker run --name chasquid \
+$ docker run -d --name chasquid \
 	-e AUTO_CERTS=mail.yourdomain.com \
 	-v chasquid_data:/data \
 	-p 25:25 -p 465:465 -p 587:587 \
@@ -81,11 +81,25 @@ $ docker run --name chasquid \
 	registry.gitlab.com/albertito/chasquid:main
 ```
 
+To view the status of the container:
+
+```sh
+docker ps -f name=chasquid
+```
+
+To stop the container:
+
+```sh
+docker stop chasquid
+```
+
 ## Debugging
 
 - To enable the monitoring HTTP server (on port `1099`), you can define the
 `ENABLE_MONITORING` environmental variable and give it any non-empty value,
 for example, `docker run -e ENABLE_MONITORING=true ...`.
+
+- To view container logs, use can use `docker logs -t -f --details chasquid`.
 
 - To get a shell on the running container for debugging,
 `docker exec -it chasquid /bin/bash`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,3 @@
-
 # Docker
 
 chasquid comes with a Dockerfile to create a container running [chasquid],
@@ -10,7 +9,6 @@ which is the recommended way to use chasquid.
 [chasquid]: https://blitiri.com.ar/p/chasquid
 [dovecot]: https://dovecot.org
 [Let's Encrypt]: https://letsencrypt.org
-
 
 ## Images
 
@@ -50,9 +48,9 @@ $ docker volume create chasquid-data
 To add your first user to the image:
 
 ```
-$ docker run \
-	--mount source=chasquid-data,target=/data \
-	--rm -it --entrypoint=/add-user.sh \
+$ docker run --rm -it \
+	-v chasquid_data:/data \
+	--entrypoint=/add-user.sh \
 	registry.gitlab.com/albertito/chasquid:main
 Email (full user@domain format): pepe@example.com
 Password:
@@ -74,11 +72,10 @@ Finally, start the container:
 
 ```sh
 $ docker run -e AUTO_CERTS=mail.yourdomain.com \
-	--mount source=chasquid-data,target=/data \
+	-v chasquid_data:/data \
 	--network host \
 	registry.gitlab.com/albertito/chasquid:main
 ```
-
 
 ## Debugging
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -104,3 +104,5 @@ for example, `docker run -e ENABLE_MONITORING=true ...`.
 - To get a shell on the running container for debugging,
 `docker exec -it chasquid /bin/bash`.
 
+- To view dovecot logs, first get a shell inside the container as described
+above, then read the `/data/dovecot/dovecot.log` file.

--- a/docker/README.md
+++ b/docker/README.md
@@ -73,7 +73,10 @@ Finally, start the container:
 ```sh
 $ docker run -e AUTO_CERTS=mail.yourdomain.com \
 	-v chasquid_data:/data \
-	--network host \
+	-p 25:25 -p 465:465 -p 587:587 \
+	-p 993:993 -p 995:995 -p 4190:4190 \
+	-p 80:80 -p 443:443 \
+	-p 127.0.0.1:1099:1099 \
 	registry.gitlab.com/albertito/chasquid:main
 ```
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -82,7 +82,11 @@ $ docker run -e AUTO_CERTS=mail.yourdomain.com \
 
 ## Debugging
 
-To get a shell on the running container for debugging, you can use `docker ps`
+- To enable the monitoring HTTP server (on port `1099`), you can define the
+`ENABLE_MONITORING` environmental variable and give it any non-empty value,
+for example, `docker run -e ENABLE_MONITORING=true ...`.
+
+- To get a shell on the running container for debugging, you can use `docker ps`
 to find the container ID, and then `docker exec -it CONTAINERID /bin/bash` to
 open a shell on the running container.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -47,7 +47,7 @@ $ docker volume create chasquid-data
 
 To add your first user to the image:
 
-```
+```sh
 $ docker run --rm -it \
 	-v chasquid_data:/data \
 	--entrypoint=/add-user.sh \

--- a/docker/README.md
+++ b/docker/README.md
@@ -74,8 +74,8 @@ Finally, start the container:
 $ docker run -d --name chasquid \
 	-e AUTO_CERTS=mail.yourdomain.com \
 	-v chasquid_data:/data \
-	-p 25:25 -p 465:465 -p 587:587 \
-	-p 993:993 -p 995:995 -p 4190:4190 \
+	-p 25:1025 -p 465:1465 -p 587:1587 \
+	-p 993:1993 -p 995:1995 -p 4190:4190 \
 	-p 80:80 -p 443:443 \
 	-p 127.0.0.1:1099:1099 \
 	registry.gitlab.com/albertito/chasquid:main

--- a/docker/README.md
+++ b/docker/README.md
@@ -71,7 +71,8 @@ and not proxying.
 Finally, start the container:
 
 ```sh
-$ docker run -e AUTO_CERTS=mail.yourdomain.com \
+$ docker run --name chasquid \
+	-e AUTO_CERTS=mail.yourdomain.com \
 	-v chasquid_data:/data \
 	-p 25:25 -p 465:465 -p 587:587 \
 	-p 993:993 -p 995:995 -p 4190:4190 \
@@ -86,7 +87,6 @@ $ docker run -e AUTO_CERTS=mail.yourdomain.com \
 `ENABLE_MONITORING` environmental variable and give it any non-empty value,
 for example, `docker run -e ENABLE_MONITORING=true ...`.
 
-- To get a shell on the running container for debugging, you can use `docker ps`
-to find the container ID, and then `docker exec -it CONTAINERID /bin/bash` to
-open a shell on the running container.
+- To get a shell on the running container for debugging,
+`docker exec -it chasquid /bin/bash`.
 

--- a/docker/chasquid.conf
+++ b/docker/chasquid.conf
@@ -4,9 +4,6 @@ smtp_address: ":25"
 submission_address: ":587"
 submission_over_tls_address: ":465"
 
-# Monitoring HTTP server.
-monitoring_address: ":1099"
-
 # Auth against dovecot.
 dovecot_auth: true
 

--- a/docker/chasquid.conf
+++ b/docker/chasquid.conf
@@ -1,8 +1,8 @@
 
 # Listening addresses.
-smtp_address: ":25"
-submission_address: ":587"
-submission_over_tls_address: ":465"
+smtp_address: ":1025"
+submission_address: ":1587"
+submission_over_tls_address: ":1465"
 
 # Auth against dovecot.
 dovecot_auth: true

--- a/docker/chasquid.conf
+++ b/docker/chasquid.conf
@@ -4,8 +4,8 @@ smtp_address: ":25"
 submission_address: ":587"
 submission_over_tls_address: ":465"
 
-# Monitoring HTTP server only bound to localhost, just in case.
-monitoring_address: "127.0.0.1:1099"
+# Monitoring HTTP server.
+monitoring_address: ":1099"
 
 # Auth against dovecot.
 dovecot_auth: true

--- a/docker/dovecot.conf
+++ b/docker/dovecot.conf
@@ -68,7 +68,7 @@ service imap-login {
     port = 0
   }
   inet_listener imaps {
-    port = 993
+    port = 1993
     ssl = yes
   }
 }
@@ -85,7 +85,7 @@ service pop3-login {
     port = 0
   }
   inet_listener pop3s {
-    port = 995
+    port = 1995
     ssl = yes
   }
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -102,6 +102,12 @@ done >> /etc/dovecot/auto-ssl.conf
 sed -i '/^hostname:/d' /etc/chasquid/chasquid.conf
 echo "hostname: '$ONE_DOMAIN'" >> /etc/chasquid/chasquid.conf
 
+# Enable/disable the monitoring http server.
+sed -i '/^monitoring_address:/d' /etc/chasquid/chasquid.conf
+if [ "$ENABLE_MONITORING" != "" ]; then
+	echo 'monitoring_address: ":1099"' >> /etc/chasquid/chasquid.conf
+fi
+
 # Start the services: dovecot in background, chasquid in foreground.
 start-stop-daemon --start --quiet --pidfile /run/dovecot.pid \
 	--exec /usr/sbin/dovecot -- -c /etc/dovecot/dovecot.conf


### PR DESCRIPTION
### First of all, this is a breaking change!

Using host network breaks Dockers network isolation security features and allows access to other services on the host if the container gets compromised, so it is generally only advised if performance is absolutely critical (avoids aditional NAT).

Also changed the monitoring address inside the config file, instead the user can choose whether to even expose the port at all (if they don't specify `-p 1099:1099` it won't be accessible), or only allow access on the host localhost (`-p 127.0.0.1:1099:1099` means it is exposed only on the host localhost), or to expose to everyone (not recommended, but they can if they really want). This change is necessary to be able to access the monitoring at all outside within the container.

Also replaced `--mount` otpions with `-v` (`--volume`) which is specifically made for volumes and is much easier to use.

Edit: Having monitoring address be `127.0.0.1:1099` means that those using the recommended bridge instead of host network are unable to use monitoring **at all**. ~Would you be interested in having an environmental variable that a user can use to change this value from the entry point script?~ On second thought, I really don't see a good reason to use host network. Added a variable to enable/disable monitoring, since the user may not want it anyway. Currently it is opt-in to enable, though, we could make it the opposite.

Edit: And if we use the bridge network, there's no need to bind to privileged ports, so we can drop the line that gives the users inside the container that capability. We just bind to some fixed port, e.g. `1025` instead of `25`, and it's up to the user what this port maps to on the host. Since Docker daemon runs as root by default, they can use privileged ports, e.g. `25:1025`, or if they are already using that port or don't want to use a privileged port, the bridge network allows them to use any port they wish, e.g. `1234:1025`, so it is much more flexible. We just got to agree which ports to use inside the container, e.g. `1025` or `2525` or something else? Let me know if you'd prefer different numbers. Also, will test later today, just in case.

Edit: Also made some README improvements:

- When running the container specify a name, so it's easier to find it later in the `docker ps` list, but also to not have to get the container ID to operate on it, those operations, like getting a shell into the container, can be done using this name instead, making it much simpler for the user.
- Run the container as a daemon and added instruction to view the status of the container, stop it, and view its logs (with timestamps and follow).
- Added instructions to view dovecot logs.