### PR TITLE
fix empty lines in maillog

### DIFF
--- a/internal/maillog/maillog.go
+++ b/internal/maillog/maillog.go
@@ -96,7 +96,7 @@ func (l *Logger) Auth(netAddr net.Addr, user string, successful bool) {
 	if !successful {
 		res = "failed"
 	}
-	msg := fmt.Sprintf("%s auth %s for %s\n", netAddr, res, user)
+	msg := fmt.Sprintf("%s auth %s for %s", netAddr, res, user)
 	l.printf("%s", msg)
 	authLog.Debugf("%s", msg)
 }


### PR DESCRIPTION
`blitiri.com.ar/go/log` handles trailing newlines, but only in the format parameter, not in the args. Because of this, the mail.log currently contains blank lines between each actual log line.

This PR fixes that small issue.